### PR TITLE
Fix undefined event parameter in Scene class

### DIFF
--- a/scene.h
+++ b/scene.h
@@ -1,15 +1,19 @@
 #pragma once
+
+#include <SDL.h>
+
 class Scene
 {
 public:
-	Scene() = default;
-	virtual ~Scene() = default;
+        Scene() = default;
+        virtual ~Scene() = default;
 
 	virtual void on_enter() = 0;
 	virtual void on_update() = 0;
-	virtual void on_draw() = 0;
-	virtual void on_input(const ExMessage& msg) = 0;
-	virtual void on_exit() = 0;
+        virtual void on_draw() = 0;
+        // Use SDL_Event instead of the undefined ExMessage type
+        virtual void on_input(const SDL_Event& event) = 0;
+        virtual void on_exit() = 0;
 
 protected:
 


### PR DESCRIPTION
## Summary
- include SDL header in `scene.h`
- replace non-existent `ExMessage` with `SDL_Event`
- add newline at end of `scene.h`

## Testing
- `g++ -std=c++11 -Ithirdparty/SDL2/include -Ithirdparty/SDL2_ttf/include -Ithirdparty/SDL2_mixer/include -Ithirdparty/SDL2_image/include -Ithirdparty/SDL2_gfx/include -Ithirdparty/cJSON/include -c main.cpp game_manager.cpp thirdparty/cJSON/cJSON.c`

------
https://chatgpt.com/codex/tasks/task_e_6840da486d4883298dcfff8243d52ef8